### PR TITLE
chore: Update nilup curl URL to include install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This template has all the power of the [Scaffold-ETH 2 dapp toolkit](https://git
 Before you begin, you need to install the following tools:
 
 - `nilup`, an installer and version manager for the [Nillion SDK tools](https://docs.nillion.com/nillion-sdk-and-tools). Install nilup:
+
+  _For the security-conscious, please download the `install.sh` script, so that you can inspect how
+  it works, before piping it to `bash`._
+
   ```
   curl https://nilup.nilogy.xyz/install.sh | bash
   ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Before you begin, you need to install the following tools:
 
 - `nilup`, an installer and version manager for the [Nillion SDK tools](https://docs.nillion.com/nillion-sdk-and-tools). Install nilup:
   ```
-  curl https://nilup.nilogy.xyz | bash
+  curl https://nilup.nilogy.xyz/install.sh | bash
   ```
   - Confirm `nilup` installation
     ```


### PR DESCRIPTION
This commit changes the URL used to instruct users to install nilup to include the /install.sh path. Even though the root path (/) is essentially an alias for /install.sh, we shouldn't lock ourselves into that forever being the case.